### PR TITLE
Added time metrics collection

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,13 @@ class QueueChecker:
 
         assert stored_value == value
 
+    async def assert_metric_time_wait(self, value: int):
+        stored_value = int(
+            await self.queue.client.get(self.queue.metrics_time_wait) or 0
+        )
+
+        assert stored_value == value
+
 
 @pytest.fixture
 def queue_checker(task_queue) -> QueueChecker:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,6 @@ if aioredis.__version__ >= "2.0":
     async def zadd_single(client: aioredis.Redis, set_name: str, key: str, value: Any):
         await client.zadd(set_name, {key: value})
 
-
 else:
 
     async def create_redis_connection(redis_uri: str):

--- a/tests/test_task_queue.py
+++ b/tests/test_task_queue.py
@@ -519,7 +519,7 @@ async def test_task_retry_delay(task_queue, queue_checker, freezer):
 
 
 @pytest.mark.asyncio
-async def test_task_wait_time_metric(task_queue, queue_checker):
+async def test_task_wait_time_metric(task_queue, queue_checker, freezer):
     await task_queue.add_task({"key": "value"})
 
     await queue_checker.assert_metric_time_wait(0)

--- a/tests/test_task_queue.py
+++ b/tests/test_task_queue.py
@@ -516,3 +516,14 @@ async def test_task_retry_delay(task_queue, queue_checker, freezer):
     await queue_checker.assert_metric_added(1)
     await queue_checker.assert_metric_taken(2)
     await queue_checker.assert_metric_requeued(1)
+
+
+@pytest.mark.asyncio
+async def test_task_wait_time_metric(task_queue, queue_checker):
+    await task_queue.add_task({"key": "value"})
+
+    await queue_checker.assert_metric_time_wait(0)
+    freezer.tick(3.0)
+
+    await task_queue.get_task()
+    await queue_checker.assert_metric_time_wait(3)

--- a/tests/test_task_queue.py
+++ b/tests/test_task_queue.py
@@ -526,4 +526,4 @@ async def test_task_wait_time_metric(task_queue, queue_checker, freezer):
     freezer.tick(3.0)
 
     await task_queue.get_task()
-    await queue_checker.assert_metric_time_wait(3)
+    await queue_checker.assert_metric_time_wait(3000)

--- a/yatq/lua/get_template_lua.py
+++ b/yatq/lua/get_template_lua.py
@@ -54,7 +54,7 @@ local function get_task_deadline (data)
 end
 
 
-local available_tasks = redis.call("ZRANGEBYSCORE", pending_key, 0, time, "LIMIT", 0, 1)
+local available_tasks = redis.call("ZRANGEBYSCORE", pending_key, 0, time, "WITHSCORES", "LIMIT", 0, 1)
 local task_key = available_tasks[1]
 
 if task_key == nil then

--- a/yatq/queue.py
+++ b/yatq/queue.py
@@ -82,6 +82,7 @@ class Queue:
         self.metrics_resurrected_key = f"{self._key_prefix}:metrics:resurrected"
         self.metrics_buried_key = f"{self._key_prefix}:metrics:buried"
         self.metrics_broken_key = f"{self._key_prefix}:metrics:broken"
+        self.metrics_time_wait = f"{self._key_prefix}:metrics:time_wait"
         self.environment = {
             "processing_key": self.processing_set_name,
             "pending_key": self.pending_set_name,
@@ -95,6 +96,7 @@ class Queue:
             "metrics_resurrected_key": self.metrics_resurrected_key,
             "metrics_buried_key": self.metrics_buried_key,
             "metrics_broken_key": self.metrics_broken_key,
+            "metrics_time_wait": self.metrics_time_wait,
             "default_timeout": DEFAULT_TIMEOUT,
             "default_task_expiration": DEFAULT_TASK_EXPIRATION,
         }

--- a/yatq/queue.py
+++ b/yatq/queue.py
@@ -229,7 +229,7 @@ class Queue:
             if task.policy == RetryPolicy.LINEAR:
                 delay = task.delay * task.retry_counter
             else:
-                delay = task.delay ** task.retry_counter
+                delay = task.delay**task.retry_counter
 
         after_time = int(time.time()) + delay
         task.state = TaskState.REQUEUED

--- a/yatq/redis_compat.py
+++ b/yatq/redis_compat.py
@@ -11,7 +11,6 @@ if aioredis.__version__ >= "2.0":  # pragma: no cover
     ):  # pragma: no cover
         return await client.evalsha(digest, 0, *args)
 
-
 else:  # pragma: no cover
     from aioredis.errors import ReplyError
 


### PR DESCRIPTION
Copied "wait time" metrics collection from internal queue implementation.
Metric value is stored in `<prefix>:metrics:time_wait` redis key as increasing millisecond value, updating on task getting.